### PR TITLE
Fixed first pr that appears in the Draft Release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,1 +1,9 @@
 version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/null"
+    schedule:
+      interval: "monthly"
+    target-branch: "null"
+    labels:
+      - "@null-dependencies"

--- a/.zeobot/config.yml
+++ b/.zeobot/config.yml
@@ -144,15 +144,15 @@ draft_release:
       labels:
         - '@security'
         - '@priority-critical'
-        - '@dependency-update'
-        - '@enhancement'
-        - '@feature'
         - '@priority-high'
+        - '@feature'
         - '@maintenance'
     # patch - version category
     patch:
       # these labels will influence the next version
       labels:
+        - '@dependency-update'
+        - '@enhancement'
         - '@priority-medium'
         - '@priority-low'
         - '@priority-very-low'
@@ -166,7 +166,6 @@ draft_release:
     - title: 'Security'
       labels:
         - '@security'
-        - '@bug-fix'
     - title: 'Enhancement'
       labels:
         - '@enhancement'

--- a/src/apps/draft-release/index.js
+++ b/src/apps/draft-release/index.js
@@ -76,7 +76,7 @@ class DraftRelease {
             if (pullObject.merged_at) {
                 if (!lastRelease) {
                     pullRequestsList.push(pullObject)
-                } else if (new Date(pullObject.merged_at) >= new Date(lastRelease.created_at)) {
+                } else if (new Date(pullObject.merged_at) > new Date(lastRelease.created_at)) {
                     pullRequestsList.push(pullObject)
                 }
             }


### PR DESCRIPTION
Due to an equality the last pr from the last release was shown in the next release.

This was fixed by changing the equality to greater:
```js
// from ->
new Date(pullObject.merged_at) >= new Date(lastRelease.created_at))
// into ->
new Date(pullObject.merged_at) > new Date(lastRelease.created_at))
```